### PR TITLE
Truly cross platform : Nov 1st deadline

### DIFF
--- a/gagbo-truly-cross-platform.md
+++ b/gagbo-truly-cross-platform.md
@@ -5,14 +5,16 @@ still encounter configuration issues. My whole `~/.vim` folder is under version
 control so I can just clone it on any computer I want my familiar Vim
 experience.
 
-But I use Windows computers and Linux computers. Even within the
-same environment, I might have different dependencies installed for the plugins I try to
-import. Also, from time to time I like to use Neovim too, to try out a few
-unique features.
+But I use Windows computers and Linux computers. Even within the same
+environment, I might have different dependencies installed for the plugins I
+try to import. Also, from time to time I like to use Neovim too, to try out a
+few unique features.
+
+All the tips in this article gravitate around being able to use if statements in
+your startup scripts.
 
 
-
-environment specific settings
+Environment specific settings
 -------------------------------------------------------------------------------
 To make environment specific settings we need to know the environment we are
 running on.
@@ -20,7 +22,7 @@ We can ask vim directly if it was compiled for Windows, otherwise a system call
 to `uname` will give the running environment. The function below returns a string
 containing the value of the running environment.
 
-```vimscript
+```vim
 function! whichEnv() abort
     if has('win64') || has('win32') || has('win16')
         return 'WINDOWS'
@@ -29,7 +31,9 @@ function! whichEnv() abort
     endif
 endfunction
 
-" Later use in another file
+"""""""""""""""""""""""""""""
+" Later use in another file "
+"""""""""""""""""""""""""""""
 if (whichEnv() =~# 'WINDOWS')
     " Enable Windows specific settings/plugins
 else if (whichEnv() =~# 'LINUX')
@@ -41,19 +45,41 @@ else
 endif
 ```
 
-Intermission : system calls optimizations
+Intermission : external shell calls optimizations
 -------------------------------------------------------------------------------
-System calls are costly
-> Make a MWE with or without loading no-stl-wednesdays or any system call in init
-> (see the difference in startuptime with or without the
-> no-stl-wednesdays plugin which is only a call to `date`)
-; caching the results as
-much as possible yields good results. Autoloading probably doesn't change
-anything about startup time : the file will be loaded on each startup because the
-init scripts will call the function. It is just done to namespace my helpers
-functions.
+External shell calls are costly, mostly because of the context switching they
+require. They are not very long, but one of the big advantages of vim is the
+very quick startup time, and having too many external calls in your startup
+will definitely have consequences on your experience.
 
-```vimscript
+To illustrate this, let's compare the startup time of Vim with a one-liner
+vimrc, where :
+- one case has `let g:dummy_string = 'dummy string'` (no external shell call),
+- the other case has `let g:dummy_string = system('date')` (one external shell
+  call)
+
+The command I used to compare the startup times was `vim --noplugin -u
+one_liner_vimrc --startuptime startup.txt`, and here is the final result :
+- no external call : `002.369  000.003: --- VIM STARTED ---`
+- external call : `093.497  000.002: --- VIM STARTED ---`
+
+The 90 ms difference in startup time is entirely due to the external system call
+(see `:h startuptime` for help on the syntax) :
+```
+# No external call
+001.246  000.021  000.021: sourcing no_externalcall_vimrc
+
+# External call
+092.540  088.869  088.869: sourcing externalcall_vimrc
+```
+
+Caching the results from any external system call as
+much as possible is important when crafting flexible `.vim/` startup scripts.
+Here is the final function I use (and call in my other scripts) to know my
+environment. The result of `system` is stored in a global variable and used
+in all scripts.
+
+```vim
 " Sets only once the value of g:env to the running environment
 " from romainl
 " https://gist.github.com/romainl/4df4cde3498fada91032858d7af213c2
@@ -67,7 +93,32 @@ function! myHelpers#setEnv() abort
        let g:env = toupper(substitute(system('uname'), '\n', '', ''))
     endif
 endfunction
+
+"""""""""""""""""""""""""""""
+" Later use in another file "
+"""""""""""""""""""""""""""""
+
+" I can call this function before every environment specific block with the
+" early return branch.
+call myHelpers#setEnv()
+if (g:Env =~# 'WINDOWS')
+    " Enable Windows specific settings/plugins
+else if (g:Env =~# 'LINUX')
+    " Enable Linux specific settings/plugins
+else if (g:Env =~# 'DARWIN')
+    " Enable MacOS specific settings/plugins
+else
+    " Other cases I can't think of like MINGW
+endif
 ```
+
+> Should I speak about autoload or just leave it as an advanced feature ?
+> Basically the solution boils down to autoloading or leaking the function
+> in the global namespace.
+Autoloading here doesn't change
+anything about startup time : the file will be loaded on each startup because the
+init scripts will call the function. It is just done to namespace my helpers
+functions.
 
 Host specific settings
 -------------------------------------------------------------------------------
@@ -78,24 +129,60 @@ method for Linux, since I have a lot more things installed on my laptop than
 there is on the cluster, where my editing doesn't need half the plugins I use
 for personal use.
 
+Linux provides [hostname](https://linux.die.net/man/1/hostname) so we can use
+the same function as before, replacing only the `toupper...` line with
+`system('hostname')`, and storing it in another `g:` variable like `g:Hostname`.
+
+_*This method may also work on Windows, but not sure*_
+
+Host specific settings are good when you know you're only cloning your `~/.vim`
+directory in a few computers on which you know what is installed. Using this to
+differentiate between 50 hosts means you will need very long if statements which
+get quickly hard to read.
+
+I still find this useful for clipboard
+handling or other purely host-specific settings.
+
+> I made this a big heading because it felt like a good thing to keep in the
+> TOC of the article, but it's really short in content (it boils down to
+> s/uname/hostname/g && s/g:Env/g:Hostname/g). Should I fuse ?
+
 Dependencies specific settings
 -------------------------------------------------------------------------------
-Even on the same environment, dependencies might not be fulfilled on all the target
-machines.
+Even on the same environment, dependencies might not be fulfilled on all the
+target machines. These dependencies can be separated into 2 categories, Vim's
+*features* and external *dependencies*. The difference I make between these 2
+is that *features* are defined at compilation time in Vim and that
+*dependencies* are external to Vim's compilation.
 
-Vim keeps track of its own feature set and you can always use `has()` to check
-for features in your scripts. See `:h has()` for all the features you can test
+Vim keeps track of its own feature set, defined at compile time. Therefore you
+can directly use vimscript to know if Vim has a feature or not, using the
+`has()` function.
+See `:h has()` for all the features you can test for
 directly within vim.
-```vimscript
+```vim
 if has('balloon_eval')
-" Do balloon stuff here
+" Do mouse tooltip-related stuff here
 endif
 ```
 
 For external dependencies (like the linters you might want to set as `makeprg`
-or the LSP servers you want to start for a project), using system calls is
-again the solution to make it work.
-> I know about which for Unix, but I actually have not tested that on Windows
+or the LSP servers you want to start for a project), using `executable()`
+instead of using a call to [which](https://linux.die.net/man/1/which) is very
+important, as it is way faster than `system`. I ran the same test case as
+before with a vimrc which only include an `executable()` call :
+```vim
+if executable('rg')
+    let g:string_date = 'dummy string'
+endif
+```
+
+and the results are almost the same as the *no external call* case :
+```
+# Important lines only
+001.991  000.136  000.136: sourcing exec_vimrc
+003.383  000.005: --- VIM STARTED ---
+```
 
 
 Bonus round : Vim 8+ and Neovim compatibility
@@ -110,17 +197,44 @@ not care about `vimrc`
 After a few updates I made in my plugins and/or colorschemes, I noticed I
 always had 2 files to change : `init.vim` and `vimrc`. I still want to keep the
 files different because there are a few settings which are actually specific to
-one software, but duplicating changes is a code smell. My solution is to use
+one software, but duplicating changes is a code smell.
+
+My solution is to use
 `runtime` heavily and externalize all the common parts of my old `vimrc`.
-> Maybe I should put those files under plugin now, but it's still more a startup
-> file than an actual plugin sooo....
+`runtime` will look for files to source with the given name in your
+`runtimepath` and will source the first one it finds. Choosing a "unique"
+folder for the sourced files (like `settings`) allows to store them all with
+any name as long as they are in the `runtimepath`. I choose to leave them
+directly in the `~/.vim` folder to have them under version control of course :
+```
+$ ls ~/.vim
+... some files
+init.vim
+vimrc
+settings/
+... other folders
+
+$ ls ~/.vim/settings
+colors.vim
+ale.vim
+... other files
+
+```
+
+```vim
+" In vimrc
+set autoindent " 'vim-specific' setting
+runtime settings/fold_fillchars.vim
+
+```
+
 
 `if has('nvim')` is exactly what you want to separate the 2 cases in your
 scripts. For example, to load plugins only for Vim or only for Neovim, you can
 put your optional plugins in `~/.vim/pack/vim_or_neovim/opt` and then use this
 kind of snippets :
 
-```vimscript
+```vim
 if has('nvim')
     " Load Neovim specific plugins
     packadd LanguageClient-neovim " This plugin is not Neovim specific anymore,
@@ -137,6 +251,10 @@ Results
 You can see a few of those principles applied on my [current
 repo](https://framagit.org/gagbo/vim-setup). Be warned that it is still a little
 bit messy, because tidying all the files and plugins is very low priority on my
-TODO list.
+TODO list. And also because writing this post made me verify and learn new
+things about how to further smooth my truly cross platform setup.
+
+
+Gerry
 
 [license link to CC 4.0](https://creativecommons.org/licenses/by/4.0/)

--- a/gagbo-truly-cross-platform.md
+++ b/gagbo-truly-cross-platform.md
@@ -47,7 +47,7 @@ endif
 
 Note that vim also has so-called *features* (the arguments in the `has`
 function) for checking respectively `'osx'` and '`osx_darwin`', but after having
-speaken with a MacOS user (I don't use it personnally), there seems to be cases
+spoken with a MacOS user (I don't use it personnally), there seems to be cases
 where using these flags for MacOS detection is not working as
 [one would guess](https://github.com/vim-advent-calendar/ideas/pull/12#issuecomment-435005197).
 

--- a/gagbo-truly-cross-platform.md
+++ b/gagbo-truly-cross-platform.md
@@ -112,12 +112,16 @@ else
 endif
 ```
 
+> For romainl : vim has "has(osx)" and even "has(osx_darwin)", why not
+> use those ?
+
+also,
 > Should I speak about autoload or just leave it as an advanced feature ?
 > Basically the solution boils down to autoloading or leaking the function
 > in the global namespace.
 Autoloading here doesn't change
 anything about startup time : the file will be loaded on each startup because the
-init scripts will call the function. It is just done to namespace my helpers
+init scripts will call the function. It is just done to namespace my helper
 functions.
 
 Host specific settings
@@ -161,8 +165,8 @@ can directly use vimscript to know if Vim has a feature or not, using the
 See `:h has()` for all the features you can test for
 directly within vim.
 ```vim
-if has('balloon_eval')
-" Do mouse tooltip-related stuff here
+if has('cscope')
+" Enable all the plugins or change settings to use cscope support
 endif
 ```
 
@@ -174,6 +178,7 @@ before with a vimrc which only include an `executable()` call :
 ```vim
 if executable('rg')
     let g:string_date = 'dummy string'
+    " usually the line here is set grepprg=rg\ --vimgrep
 endif
 ```
 
@@ -257,4 +262,5 @@ things about how to further smooth my truly cross platform setup.
 
 Gerry
 
-[license link to CC 4.0](https://creativecommons.org/licenses/by/4.0/)
+This article is licensed under
+[Creative Commons v4.0](https://creativecommons.org/licenses/by/4.0/)

--- a/truly-cross-platform/command.txt
+++ b/truly-cross-platform/command.txt
@@ -1,0 +1,1 @@
+vim --noplugin -u {syscall_vimrc, NONE} --startuptime {startup_syscall,startup_no_syscall}

--- a/truly-cross-platform/exec_startup.txt
+++ b/truly-cross-platform/exec_startup.txt
@@ -1,0 +1,30 @@
+
+
+times in msec
+ clock   self+sourced   self:  sourced script
+ clock   elapsed:              other lines
+
+000.009  000.009: --- VIM STARTING ---
+000.127  000.118: Allocated generic buffers
+000.233  000.106: locale set
+000.242  000.009: window checked
+001.037  000.795: inits 1
+001.087  000.050: parsing arguments
+001.089  000.002: expanding arguments
+001.108  000.019: shell init
+001.612  000.504: Termcap init
+001.646  000.034: inits 2
+001.793  000.147: init highlight
+001.991  000.136  000.136: sourcing exec_vimrc
+002.002  000.073: sourcing vimrc file(s)
+002.020  000.018: inits 3
+002.050  000.030: setting raw mode
+002.055  000.005: start termcap
+002.073  000.018: clearing screen
+002.841  000.768: opening buffers
+002.846  000.005: BufEnter autocommands
+002.847  000.001: editing files in windows
+002.857  000.010: VimEnter autocommands
+002.858  000.001: before starting main loop
+003.378  000.520: first screen update
+003.383  000.005: --- VIM STARTED ---

--- a/truly-cross-platform/exec_vimrc
+++ b/truly-cross-platform/exec_vimrc
@@ -1,0 +1,3 @@
+if executable('rg')
+    let g:string_date = 'dummy string'
+endif

--- a/truly-cross-platform/no_syscall_startup.txt
+++ b/truly-cross-platform/no_syscall_startup.txt
@@ -1,0 +1,30 @@
+
+
+times in msec
+ clock   self+sourced   self:  sourced script
+ clock   elapsed:              other lines
+
+000.005  000.005: --- VIM STARTING ---
+000.085  000.080: Allocated generic buffers
+000.145  000.060: locale set
+000.150  000.005: window checked
+000.606  000.456: inits 1
+000.636  000.030: parsing arguments
+000.637  000.001: expanding arguments
+000.651  000.014: shell init
+000.994  000.343: Termcap init
+001.018  000.024: inits 2
+001.188  000.170: init highlight
+001.246  000.021  000.021: sourcing no_syscall_vimrc
+001.250  000.041: sourcing vimrc file(s)
+001.260  000.010: inits 3
+001.274  000.014: setting raw mode
+001.278  000.004: start termcap
+001.296  000.018: clearing screen
+001.818  000.522: opening buffers
+001.822  000.004: BufEnter autocommands
+001.824  000.002: editing files in windows
+001.833  000.009: VimEnter autocommands
+001.834  000.001: before starting main loop
+002.366  000.532: first screen update
+002.369  000.003: --- VIM STARTED ---

--- a/truly-cross-platform/no_syscall_vimrc
+++ b/truly-cross-platform/no_syscall_vimrc
@@ -1,0 +1,1 @@
+let g:string_date = 'dummy_string'

--- a/truly-cross-platform/syscall_startup.txt
+++ b/truly-cross-platform/syscall_startup.txt
@@ -1,0 +1,30 @@
+
+
+times in msec
+ clock   self+sourced   self:  sourced script
+ clock   elapsed:              other lines
+
+000.017  000.017: --- VIM STARTING ---
+000.346  000.329: Allocated generic buffers
+000.567  000.221: locale set
+000.581  000.014: window checked
+001.957  001.376: inits 1
+002.045  000.088: parsing arguments
+002.050  000.005: expanding arguments
+002.101  000.051: shell init
+003.144  001.043: Termcap init
+003.194  000.050: inits 2
+003.593  000.399: init highlight
+092.540  088.869  088.869: sourcing bad_vimrc
+092.546  000.084: sourcing vimrc file(s)
+092.558  000.012: inits 3
+092.583  000.025: setting raw mode
+092.589  000.006: start termcap
+092.627  000.038: clearing screen
+093.078  000.451: opening buffers
+093.081  000.003: BufEnter autocommands
+093.082  000.001: editing files in windows
+093.089  000.007: VimEnter autocommands
+093.090  000.001: before starting main loop
+093.495  000.405: first screen update
+093.497  000.002: --- VIM STARTED ---

--- a/truly-cross-platform/syscall_vimrc
+++ b/truly-cross-platform/syscall_vimrc
@@ -1,0 +1,1 @@
+let g:string_date = system('date')


### PR DESCRIPTION
Trying to follow the calendar here. Here's a more fleshed out version for the article.

All quotes are actually comments. @romainl I've put a small question for you in the middle : why still using the call to `uname` in setEnv() while vim has `osx` and `osx_darwin` features ? Are there cases where uname returns darwin but both `has(osx)` and `has(osx_darwin)` are false ?